### PR TITLE
Don't send data before returning greeting

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -76,15 +76,14 @@ test('terminates', () => {
 })
 
 test('sends handshake before any data when source emits value after handshake', () => {
-  let counter = 0
   let emit
   const source$ = (t, d) => {
     let sink
     if (t === 0) {
       sink = d
       sink(0) // no talkback
-      sink(1, ++counter) // emit initial value
       emit = value => sink(1, value)
+      emit(29) // emit initial value
     } else if (t === 2 && sink) {
       sink(2)
     }
@@ -97,7 +96,7 @@ test('sends handshake before any data when source emits value after handshake', 
   expect(sink$).toHaveBeenCalled()
   expect(sink$).toHaveBeenCalledTimes(2)
   expect(sink$.mock.calls[0][0]).toBe(0)
-  expect(sink$.mock.calls[1]).toEqual([1, 1])
+  expect(sink$.mock.calls[1]).toEqual([1, 29]) // initial value
 
   // emit value
   emit(42)


### PR DESCRIPTION
Existing implementation was breaking this rule of the Callbag contract...

> A callbag MUST NOT be delivered data before it has been greeted

...by providing a data (`1`) call _before_ returning the greeting (`0`), if-and-only-if the source it was given was the kind of source (like `callbag-remember` itself) that returns data immediately after handshake.

Fix is achieved by keeping track of parallel array of booleans, `handshook` (not a real word, but...?), to know which sinks have had their handshake completed, and then completing the handshake if needed after subscribing to source.